### PR TITLE
shell out to powershell rather than coreutils cp on Windows

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -38,13 +38,13 @@ provides(BuildProcess,
 		@build_steps begin
 			ChangeDirectory(extractdir(32))
 			FileRule(destw(32), @build_steps begin
-				`cp libnlopt-0.dll $(destw(32))`
+				`powershell -Command "cp libnlopt-0.dll $(destw(32))"`
 				end)
 		end
 		@build_steps begin
 			ChangeDirectory(extractdir(64))
 			FileRule(destw(64), @build_steps begin
-				`cp libnlopt-0.dll $(destw(64))`
+				`powershell -Command "cp libnlopt-0.dll $(destw(64))"`
 				end)
 		end
 	end), libnlopt, os = :Windows)


### PR DESCRIPTION
alternate fix for #48 that leaves in place the BinDeps messiness

(another alternative would be to repackage the zip files including an internal folder rather than dumping everything into the current directory, then go with a slightly modified version of #49)

~~edit: will squash if wanted, once I get something that works~~ done

edit2: powershell to the rescue as the only sane shell environment that's installed by default on windows. fixes #48, closes #49