### PR TITLE
bump MathProgBase requires and update JuMP syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,19 +119,19 @@ The same problem can be solved by using the JuMP interface to NLopt:
     a2 = -1
     b2 = 1
 
-    @defVar(m, x1)
-    @defVar(m, x2 >= 0)
+    @variable(m, x1)
+    @variable(m, x2 >= 0)
 
-    @setNLObjective(m, Min, sqrt(x2))
-    @addNLConstraint(m, x2 >= (a1*x1+b1)^3)
-    @addNLConstraint(m, x2 >= (a2*x1+b2)^3)
+    @NLobjective(m, Min, sqrt(x2))
+    @NLconstraint(m, x2 >= (a1*x1+b1)^3)
+    @NLconstraint(m, x2 >= (a2*x1+b2)^3)
 
-    setValue(x1, 1.234)
-    setValue(x2, 5.678)
+    setvalue(x1, 1.234)
+    setvalue(x2, 5.678)
 
     status = solve(m)
 
-    println("got ", getObjectiveValue(m), " at ", [getValue(x1),getValue(x2)])
+    println("got ", getobjectivevalue(m), " at ", [getvalue(x1),getvalue(x2)])
 
 The output should be:
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4
 @osx Homebrew
 BinDeps
-MathProgBase 0.4.0 0.5.0-
+MathProgBase 0.5 0.6

--- a/test/tutorial_jump.jl
+++ b/test/tutorial_jump.jl
@@ -9,23 +9,23 @@ b1 = 0
 a2 = -1
 b2 = 1
 
-@defVar(m, x1)
-@defVar(m, x2 >= 0)
+@variable(m, x1)
+@variable(m, x2 >= 0)
 
-@setNLObjective(m, Min, sqrt(x2))
-@addNLConstraint(m, x2 >= (a1*x1+b1)^3)
-@addNLConstraint(m, x2 >= (a2*x1+b2)^3)
+@NLobjective(m, Min, sqrt(x2))
+@NLconstraint(m, x2 >= (a1*x1+b1)^3)
+@NLconstraint(m, x2 >= (a2*x1+b2)^3)
 
-setValue(x1, 1.234)
-setValue(x2, 5.678)
+setvalue(x1, 1.234)
+setvalue(x2, 5.678)
 
 status = solve(m)
 
-println("got ", getObjectiveValue(m), " at ", [getValue(x1),getValue(x2)])
+println("got ", getobjectivevalue(m), " at ", [getvalue(x1),getvalue(x2)])
 
-@test_approx_eq_eps getValue(x1) 1/3 1e-5
-@test_approx_eq_eps getValue(x2) 8/27 1e-5
-@test_approx_eq_eps getObjectiveValue(m) sqrt(8/27) 1e-5
+@test_approx_eq_eps getvalue(x1) 1/3 1e-5
+@test_approx_eq_eps getvalue(x2) 8/27 1e-5
+@test_approx_eq_eps getobjectivevalue(m) sqrt(8/27) 1e-5
 @test status == :Optimal
 
 


### PR DESCRIPTION
MathProgBase 0.5 was just tagged, though it doesn't require any changes for nonlinear solvers. Also updated the syntax in the JuMP examples.