### PR TITLE
Fix deprecation warnings for Julia v0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 julia:
     - 0.4
     - 0.5
+    - 0.6
     - nightly
 notifications:
     email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ environment:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/NLopt.jl
+++ b/src/NLopt.jl
@@ -52,7 +52,7 @@ end
 # apparently default to sizeof(enum)==sizeof(int).]  So, if Julia is
 # ever ported to ARM, this may need to be fixed (since all of these enums
 # will be packed into a single byte on -fshort-enums architectures).
-typealias Cenum Cint
+const Cenum = Cint
 cenum(x) = convert(Cenum, x)
 
 # enum nlopt_algorithm
@@ -128,7 +128,7 @@ const res2sym = Dict{Cenum,Symbol}(FAILURE=>:FAILURE, INVALID_ARGS=>:INVALID_ARG
 ############################################################################
 # wrapper around nlopt_opt type
 
-typealias _Opt Ptr{Void} # nlopt_opt
+const _Opt = Ptr{Void} # nlopt_opt
 
 # pass both f and o to the callback so that we can handle exceptions
 type Callback_Data

--- a/src/NLoptSolverInterface.jl
+++ b/src/NLoptSolverInterface.jl
@@ -90,7 +90,7 @@ function SolverInterface.loadproblem!(m::NLoptMathProgModel, numVar::Integer, nu
     ineqidx = find(g_lb .!= g_ub)
 
     # map from eqidx/ineqidx to index in equalities/inequalities
-    constrmap = Array(Int,numConstr)
+    constrmap = Array{Int}(numConstr)
     for i in 1:length(eqidx)
         constrmap[eqidx[i]] = i
     end


### PR DESCRIPTION
Made changes due to deprecation warnings I was getting for Julia v0.6