### PR TITLE
Fix Travis on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ julia:
     - 0.5
     - 0.6
     - nightly
+addons:
+    apt: # apt-get for linux
+        packages:
+            - libnlopt0 # We install it this way to be able to run Travis with `sudo: false`
 notifications:
     email: false
 sudo: false


### PR DESCRIPTION
The build was failing on Travis because it was trying to install NLopt via apt-get and then failed because `sudo` was disabled on Travis.