### PR TITLE
use dot overloading in 0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ inequality_constraint!(opt, (x,g) -> myconstraint(x,g,2,0), 1e-8)
 inequality_constraint!(opt, (x,g) -> myconstraint(x,g,-1,1), 1e-8)
 
 (minf,minx,ret) = optimize(opt, [1.234, 5.678])
-count = numevals(opt) # the number of function evaluations
+count = opt.numevals # the number of function evaluations
 println("got $minf at $minx after $count iterations (returned $ret)")
 ```
 

--- a/test/tutorial.jl
+++ b/test/tutorial.jl
@@ -24,12 +24,11 @@ function myconstraint(x::Vector, grad::Vector, a, b)
 end
 
 opt = Opt(:LD_MMA, 2)
-lower_bounds!(opt, [-Inf, 0.])
-xtol_rel!(opt,1e-4)
-
-min_objective!(opt, myfunc)
-inequality_constraint!(opt, (x,g) -> myconstraint(x,g,2,0), 1e-8)
-inequality_constraint!(opt, (x,g) -> myconstraint(x,g,-1,1), 1e-8)
+opt.lower_bounds = [-Inf, 0.]
+opt.xtol_rel = 1e-4
+opt.min_objective = myfunc
+opt.inequality_constraint = (x,g) -> myconstraint(x,g,2,0)
+opt.inequality_constraint = (x,g) -> myconstraint(x,g,-1,1)
 
 (minf,minx,ret) = optimize(opt, [1.234, 5.678])
 println("got $minf at $minx after $count iterations (returned $ret)")
@@ -38,4 +37,4 @@ println("got $minf at $minx after $count iterations (returned $ret)")
 @test minx[2] ≈ 8/27 rtol=1e-5
 @test minf ≈ sqrt(8/27) rtol=1e-5
 @test ret == :XTOL_REACHED
-@test numevals(opt) == count
+@test opt.numevals == count


### PR DESCRIPTION
This lets you do things like `o.maxeval = 1000` instead of `maxeval!(o, 1000)`.   Eventually, my plan is to deprecate the latter functions.