### PR TITLE
make `Callback_Data` mutable

### DIFF
--- a/src/NLopt.jl
+++ b/src/NLopt.jl
@@ -103,7 +103,7 @@ Base.:(==)(r::Result, s::Symbol) = s == r
 const _Opt = Ptr{Cvoid} # nlopt_opt
 
 # pass both f and o to the callback so that we can handle exceptions
-struct Callback_Data
+mutable struct Callback_Data
     f::Function
     o::Any # should be Opt, but see Julia issue #269
 end


### PR DESCRIPTION
The interop here depends on `Callback_Data` objects being heap allocated with stable addresses, so they need to be mutable. I believe this should be backwards-compatible, but will be necessary in the future (https://github.com/JuliaLang/julia/pull/34126).