### PR TITLE
new algorithm-parameter API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ NLopt_jll = "079eb43e-fd8e-5478-9966-2cf3e3edb778"
 MathOptInterface = "0.9.17"
 MathProgBase = "0.5, 0.6, 0.7, 0.8"
 julia = "1.3"
+NLopt_jll = "2.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/tutorial.jl
+++ b/test/tutorial.jl
@@ -30,6 +30,13 @@ opt.min_objective = myfunc
 opt.inequality_constraint = (x,g) -> myconstraint(x,g,2,0)
 opt.inequality_constraint = (x,g) -> myconstraint(x,g,-1,1)
 
+# test algorithm-parameter API
+opt.params["verbosity"] = 0
+opt.params["inner_maxeval"] = 10
+opt.params["dual_alg"] = NLopt.LD_MMA
+@test opt.params == Dict("verbosity"=>0, "inner_maxeval"=>10, "dual_alg"=>Int(NLopt.LD_MMA))
+@test get(opt.params, "foobar", 3.14159) === 3.14159
+
 (minf,minx,ret) = optimize(opt, [1.234, 5.678])
 println("got $minf at $minx after $count iterations (returned $ret)")
 


### PR DESCRIPTION
Exposes an `opt.params` dictionary-like interface for the new algorithm-parameters API in NLopt 2.7 (stevengj/nlopt#365)