### PR TITLE
Fix #133, remove_constraints!(opt) doesn't work; chkn() not defined

### DIFF
--- a/src/NLopt.jl
+++ b/src/NLopt.jl
@@ -428,10 +428,10 @@ end
 
 function remove_constraints!(o::Opt)
     resize!(getfield(o, :cb), 1)
-    chkn(ccall((:nlopt_remove_inequality_constraints,libnlopt),
-               Result, (_Opt,), o))
-    chkn(ccall((:nlopt_remove_equality_constraints,libnlopt),
-               Result, (_Opt,), o))
+    chk(o, ccall((:nlopt_remove_inequality_constraints,libnlopt),
+                 Result, (_Opt,), o))
+    chk(o, ccall((:nlopt_remove_equality_constraints,libnlopt),
+                 Result, (_Opt,), o))
 end
 
 ############################################################################

--- a/test/fix133.jl
+++ b/test/fix133.jl
@@ -1,0 +1,63 @@
+using NLopt, Test
+
+# Objective function
+function rosenbrock(x::Vector, grad::Vector)
+    if length(grad) > 0
+        grad[1] = -400 * x[1] * (x[2] - x[1]^2) - 2 * (1 - x[1])
+        grad[2] = 200 * (x[2] - x[1]^2)
+    end
+    (1 - x[1])^2 + 100*(x[2] - x[1]^2)^2
+end
+
+function ineq01(x::Vector, grad::Vector)
+    if length(grad) > 0
+        grad[1] = 1
+        grad[2] = 2
+    end
+    x[1] + 2 * x[2] - 1
+end
+
+function ineq02(x::Vector, grad::Vector)
+    if length(grad) > 0
+        grad[1] = 2*x[1]
+        grad[2] = 1
+    end
+    x[1]^2 + x[2] - 1
+end
+
+function ineq03(x::Vector, grad::Vector)
+    if length(grad) > 0
+        grad[1] = 2*x[1]
+        grad[2] = -1
+    end
+    x[1]^2 - x[2] - 1
+end
+
+function eq01(x::Vector, grad::Vector)
+    if length(grad) > 0
+        grad[1] = 2
+        grad[2] = 1
+    end
+    2 * x[1] + x[2] - 1
+end
+
+opt = Opt(:LD_SLSQP, 2)
+opt.lower_bounds = [0, -0.5]
+opt.upper_bounds = [1, 2]
+opt.xtol_rel = 1e-21
+opt.min_objective = rosenbrock
+opt.inequality_constraint = ineq01
+opt.inequality_constraint = ineq02
+opt.inequality_constraint = ineq03
+opt.equality_constraint = eq01
+
+(minf,minx,ret) = optimize(opt, [0.5, 0])
+println("got $minf at $minx with constraints (returned $ret)")
+@test minx[1] ≈ 0.4149 rtol=1e-3
+@test minx[2] ≈ 0.1701 rtol=1e-3
+
+remove_constraints!(opt)
+(minf,minx,ret) = optimize(opt, [0.5, 0])
+println("got $minf at $minx after removing constraints (returned $ret)")
+@test minx[1] ≈ 1 rtol=1e-5
+@test minx[2] ≈ 1 rtol=1e-5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,3 @@
 include("tutorial.jl")
+include("fix133.jl")
 include("MPB_wrapper.jl")


### PR DESCRIPTION
Proposed fix for issue #133 

### Purpose
The purpose of this pull request is to fix issue #133. Currently, `remove_constraints!(opt)` produces the following error:
```julia
UndefVarError: chkn not defined

Stacktrace:
 [1] remove_constraints!(::Opt) at /Users/myname/.julia/packages/NLopt/eqN9a/src/NLopt.jl:457
 [2] top-level scope at In[13]:1
```
The problem is that there is no function named `chkn`.

### Proposal
It appears that the intention of the missing function is to check for any errors thrown by NLopt. The function `chk` already does this. Therefore, I have simply redefined `remove_constraints!` to use `chk` instead of `chkn`. 

### Additional Notes
I have also included a test file, `fix133.jl`, where I test `remove_constraints!(::Opt)`.

Please note that I'm not a Julia expert and this is my first ever pull request. So, I'm not too sure whether I've done this PR thing correctly. Any constructive feedback will be much appreciated.