### PR TITLE
Implement local_optimizer for MOI interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,22 @@ got 0.5443310477213124 at [0.3333333342139688,0.29629628951338166]
 Note that the MathOptInterface interface sets slightly different convergence tolerances by default (these default values are given by the `NLopt.DEFAULT_OPTIONS` dictionary),
 so the outputs from the two problems are not identical.
 
+Some algorithms need a local optimizer. These are set with `local_optimizer`, e.g.,
+```julia
+model = Model(NLopt.Optimizer)
+set_optimizer_attribute(model, "algorithm", :AUGLAG)
+set_optimizer_attribute(model, "local_optimizer", :LD_LBFGS)
+```
+To parametrize the local optimizer, pass use the `NLopt.Opt` interface, e.g.,
+```julia
+model = Model(NLopt.Optimizer)
+set_optimizer_attribute(model, "algorithm", :AUGLAG)
+local_optimizer = NLopt.Opt(:LD_LBFGS, num_variables)
+local_optimizer.xtol_rel = 1e-4
+set_optimizer_attribute(model, "local_optimizer", local_optimizer)
+```
+where `num_variables` is the number of variables of the optimization problem.
+
 ## Reference
 
 The main purpose of this section is to document the syntax and unique

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -84,6 +84,7 @@ const DEFAULT_OPTIONS = Dict{String, Any}(
     "population" => 0,
     "seed" => nothing,
     "vector_storage" => 0,
+    "local_optimizer" => nothing,
 )
 
 function Optimizer()
@@ -776,6 +777,15 @@ function MOI.optimize!(model::Optimizer)
     # TODO: Reuse model.inner for incremental solves if possible.
     num_variables = length(model.variable_info)
     model.inner = Opt(model.options["algorithm"], num_variables)
+    local_optimizer = model.options["local_optimizer"]
+    if local_optimizer !== nothing
+        if local_optimizer isa Symbol
+            local_optimizer = Opt(local_optimizer, num_variables)
+        else
+            local_optimizer = Opt(local_optimizer.algorithm, num_variables)
+        end
+        local_optimizer!(model.inner, local_optimizer)
+    end
 
     # load parameters
     stopval!(model.inner, model.options["stopval"])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
 include("tutorial.jl")
 include("fix133.jl")
 include("MPB_wrapper.jl")
+include("MOI_wrapper.jl")


### PR DESCRIPTION
It's a bit unfortunate that the number of variables should be set in order to parameterize the local solver. Is there a workaround ?

Closes https://github.com/JuliaOpt/NLopt.jl/issues/126#issuecomment-882081623