### PR TITLE
Support loading extension in precompiled package

### DIFF
--- a/src/NLopt.jl
+++ b/src/NLopt.jl
@@ -634,6 +634,8 @@ if !isdefined(Base, :get_extension)
     include("../ext/NLoptMathOptInterfaceExt.jl")
     using .NLoptMathOptInterfaceExt
     const Optimizer = NLoptMathOptInterfaceExt.Optimizer
+else
+    global Optimizer
 end
 
 end # module


### PR DESCRIPTION
The global needs to exist in the base package to avoid the error

    Creating a new global in closed module `NLopt` (`Optimizer`) breaks incremental compilation because the side effects will not be permanent.

This only happens if `NLopt` and `MathOptInterface` are both loaded during precompilation. It's still unfortunate that the global is not const anymore but this would at least fix the error.