### PR TITLE
Fix MOI.get for MOI.ConstraintFunction

### DIFF
--- a/ext/NLoptMathOptInterfaceExt.jl
+++ b/ext/NLoptMathOptInterfaceExt.jl
@@ -264,7 +264,7 @@ function MOI.get(
     ::MOI.ConstraintFunction,
     c::MOI.ConstraintIndex{F,S},
 ) where {F<:_F_TYPES,S}
-    return _constraints(model, F, S)[c.value].func
+    return copy(_constraints(model, F, S)[c.value].func)
 end
 
 function MOI.get(


### PR DESCRIPTION
Found by https://github.com/jump-dev/MathOptInterface.jl/pull/2328

(Next version of MOI will add tests for this.)