### PR TITLE
Avoid exception handling for verifying algorithm validity

### DIFF
--- a/src/NLopt.jl
+++ b/src/NLopt.jl
@@ -64,6 +64,12 @@ end
 
 const sym2alg = Dict(Symbol(i)=>i for i in instances(Algorithm))
 
+function Algorithm(name::Symbol)
+    alg = get(sym2alg, name, nothing)
+    alg === nothing && throw(ArgumentError("unknown algorithm $name"))
+    alg
+end
+
 # enum nlopt_result
 @enum Result::Cint begin
     FORCED_STOP=-5
@@ -118,11 +124,7 @@ mutable struct Opt
         end
         Opt(p)
     end
-    Opt(alg::Integer, n::Integer) = Opt(Algorithm(alg), n)
-    Opt(algorithm::Symbol, n::Integer) = Opt(try sym2alg[algorithm]
-                                             catch
-                         throw(ArgumentError("unknown algorithm $algorithm"))
-                                             end, n)
+    Opt(algorithm::Union{Integer,Symbol}, n::Integer) = Opt(Algorithm(algorithm), n)
 end
 
 Base.unsafe_convert(::Type{_Opt}, o::Opt) = getfield(o, :opt) # for passing to ccall
@@ -345,11 +347,7 @@ function algorithm_name(a::Algorithm)
     return unsafe_string(s)
 end
 
-algorithm_name(a::Integer) = algorithm_name(Algorithm(a))
-algorithm_name(a::Symbol) = algorithm_name(try sym2alg[a]
-                                           catch
-                             throw(ArgumentError("unknown algorithm $a"))
-                                           end)
+algorithm_name(a::Union{Integer,Symbol}) = algorithm_name(Algorithm(a))
 algorithm_name(o::Opt) = algorithm_name(algorithm(o))
 
 function Base.show(io::IO, ::MIME"text/plain", a::Algorithm)

--- a/src/NLopt.jl
+++ b/src/NLopt.jl
@@ -67,7 +67,7 @@ const sym2alg = Dict(Symbol(i)=>i for i in instances(Algorithm))
 function Algorithm(name::Symbol)
     alg = get(sym2alg, name, nothing)
     alg === nothing && throw(ArgumentError("unknown algorithm $name"))
-    alg
+    return alg::Algorithm
 end
 
 # enum nlopt_result

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,3 +26,8 @@ end
     )
     @test_throws err opt.initial_step
 end
+
+@testset "invalid algorithms" begin
+    @test_throws ArgumentError("unknown algorithm BILL") Algorithm(:BILL)
+    @test_throws ArgumentError("unknown algorithm BILL") Opt(:BILL, 420)
+end


### PR DESCRIPTION
Currently, when a `Symbol` is passed to the `Opt` constructor or the `algorithm_name` function, the corresponding `Algorithm` object is obtained via a `Dict` lookup inside of a `try`/`catch`, where the `catch` permits throwing a more informative error. The use of exception handling here isn't necessary though; rather than using `getindex` and catching any resulting exception, we can instead use `get` with a default value that does not correspond to a valid algorithm and check for equality with that. (Alternatively we could guard the `getindex` with a `haskey` but that requires performing the lookup twice.) This change to using `get` is implemented here.

To avoid duplicating the code that checks a `Symbol` for validity as an algorithm across multiple functions, I've defined a constructor method `Algorithm(::Symbol)` that includes this check. This also provides a pleasant simplification of the methods required, since `Symbol` and `Integer` inputs can now go through the same `Opt` and `algorithm_name` methods.