### PR TITLE
Remove error throwing branch on FAILURE

### DIFF
--- a/src/NLopt.jl
+++ b/src/NLopt.jl
@@ -223,6 +223,8 @@ function chk(o::Opt, result::Result)
             if e !== nothing && !isa(e, ForcedStop)
                 throw(e)
             end
+        else
+            error("nlopt failure $result", _errmsg(o))
         end
     end
     return nothing
@@ -625,7 +627,6 @@ function optimize!(o::Opt, x::Vector{Cdouble})
     ret = ccall((:nlopt_optimize,libnlopt), Result, (_Opt, Ptr{Cdouble},
                                                      Ptr{Cdouble}),
                 o, x, opt_f)
-    chk(o, ret)
     return (opt_f[1], x, Symbol(ret))
 end
 

--- a/src/NLopt.jl
+++ b/src/NLopt.jl
@@ -223,8 +223,6 @@ function chk(o::Opt, result::Result)
             if e !== nothing && !isa(e, ForcedStop)
                 throw(e)
             end
-        else
-            error("nlopt failure $result", _errmsg(o))
         end
     end
     return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,7 +70,7 @@ end
             G[1] = -2 * (1 - x[1]) - 400 * x[1] * (x[2] - x[1]^2)
             G[2] = 200 * (x[2] - x[1]^2)
         end
-        (1 - x[1])^2 + 100 * (x[2] - x[1]^2)^2
+        return (1 - x[1])^2 + 100 * (x[2] - x[1]^2)^2
     end
     function circ_cons(res, x, J)
         res[1] = x[1]^2 + x[2]^2 - 1.0
@@ -78,8 +78,8 @@ end
             J[1, 1] = 2x[1]
             J[2, 1] = 2x[2]
         end
+        return
     end
-
     opt = Opt(:AUGLAG, 2)
     opt.local_optimizer = Opt(:LD_LBFGS, 2)
     opt.min_objective = rosenbrock

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,4 +87,5 @@ end
     (minf, minx, ret) = optimize(opt, [0.5, 0.5])
     @test minf < rosenbrock([0.5, 0.5], [])
     @test sum(abs2, minx) ≈ 1.0
+    @test ret == :FAILURE
 end


### PR DESCRIPTION
The added test should demonstrate that it'll be useful to return the result even with `FAILURE` instead of throwing a very uninformative error.